### PR TITLE
Update homepage and fix eslint errors and warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 node_modules/
 npm-debug.log
+
+# visual studio code
+.vscode

--- a/bin/is-mongodb-running.js
+++ b/bin/is-mongodb-running.js
@@ -5,7 +5,6 @@ var path = require('path');
 var fs = require('fs');
 var chalk = require('chalk');
 var figures = require('figures');
-var format = require('util').format;
 
 var usage = fs.readFileSync(path.resolve(__dirname, '../usage.txt')).toString();
 var args = require('minimist')(process.argv.slice(2), {
@@ -19,11 +18,11 @@ var lookup = require('../');
 var pkg = require('../package.json');
 
 if (args.help || args.h) {
-  console.error(usage);
+  console.error(usage); // eslint-disable-line no-console
   process.exit(1);
 }
 if (args.version) {
-  console.error(pkg.version);
+  console.error(pkg.version); // eslint-disable-line no-console
   process.exit(1);
 }
 
@@ -32,22 +31,22 @@ lookup(args, function(err, res) {
     if (args.json) {
       err = JSON.stringify(err, null, 2);
     }
-    console.error(chalk.red(figures.cross), err.message);
-    console.error(chalk.gray(err.stack));
+    console.error(chalk.red(figures.cross), err.message); // eslint-disable-line no-console
+    console.error(chalk.gray(err.stack)); // eslint-disable-line no-console
     process.exit(1);
     return;
   }
   if (args.json) {
-    console.log(JSON.stringify(res, null, 2));
+    console.log(JSON.stringify(res, null, 2)); // eslint-disable-line no-console
   } else {
     if (res.length === 0) {
-      console.log('☹ No MongoDB instances running');
+      console.log('☹ No MongoDB instances running'); // eslint-disable-line no-console
       return;
     }
-    console.log(chalk.green(figures.tick),
+    console.log(chalk.green(figures.tick), // eslint-disable-line no-console
       ' Yep!', res.length, 'MongoDB instance(s) running:');
     res.map(function(d, i) {
-      console.log('  ', i + 1 + '.',
+      console.log('  ', i + 1 + '.',  // eslint-disable-line no-console
         'port',
         chalk.bold(d.port),
         'with pid',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bin": {
     "is-mongodb-running": "bin/is-mongodb-running.js"
   },
-  "homepage": "http://mongodb-js.github.io/is-mongodb-running",
+  "homepage": "https://github.com/mongodb-js/is-mongodb-running",
   "repository": {
     "type": "git",
     "url": "git://github.com/mongodb-js/is-mongodb-running.git"
@@ -26,7 +26,7 @@
     "ps-node": "0.0.5"
   },
   "devDependencies": {
-    "eslint-config-mongodb-js": "^0.1.6",
+    "eslint-config-mongodb-js": "^2.3.0",
     "jshint": "^2.6.3",
     "mocha": "^2.3.3",
     "mongodb-js-fmt": "0.0.3",


### PR DESCRIPTION
Update homepage to be the GitHub page. Previously set to mongodb-js GitHub pages link that was invalid.

When running eslint checks, the following errors would occur:

```
1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords
```

This was fixed in version 2.1.0 of eslint-mongodb-js package. Just needed updated.

Remove unused module.

Clean up no-console warnings with single-line eslint disables. The console seems appropiate here.