### PR TITLE
Add windows support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,62 +2,95 @@ var lsof = require('lsof');
 var ps = require('ps-node');
 var _ = require('lodash');
 var debug = require('debug')('is-mongodb-running');
+var netstat = require('node-netstat');
+
+var isWin = process.platform === 'win32';
 
 function fromPID(pid, fn) {
-  lsof.raw(pid, function(fds) {
-    debug('lsof.raw says', fds);
-    // fds = [
-    //   {
-    //     command: 'mongod',
-    //     pid: '19989',
-    //     user: 'lucas',
-    //     fd: '5u',
-    //     type: 'IPv4',
-    //     device: '0x61872ae41ba04f21',
-    //     'size/off': '0t0',
-    //     node: 'TCP',
-    //     name: '*:27017',
-    //     undefined: '(LISTEN)'
-    //   }
-    // ];
-    var res = _.chain(fds)
-      .filter(function(d) {
-        return _.get(d, 'node') === 'TCP';
-      })
-      .map(function(d) {
-        return {
-          port: parseInt(d.name.split(':')[1], 10),
-          pid: parseInt(d.pid, 10)
-        };
-      })
-      .value();
+  if (isWin) {
+    var res = [];
 
-    debug('parsed result is', res);
-    return fn(null, res);
-  });
-}
+    netstat({
+      filter: {
+        pid: pid,
+        protocol: 'tcp'
+      },
+      done: function() {
+        // Called once netstat command is completely done
+        // Return list of results
+        fn(null, res);
+      }
+    }, function(data) {
+      // Called for each line that matches filter
+      // Push results to list
+      debug('netstat entry says ', data);
+      res.push({
+        port: data.local.port,
+        pid: data.pid
+      });
+    });
+  } else {
+    lsof.raw(pid, function(fds) {
+      debug('lsof.raw says', fds);
+      // fds = [
+      //   {
+      //     command: 'mongod',
+      //     pid: '19989',
+      //     user: 'lucas',
+      //     fd: '5u',
+      //     type: 'IPv4',
+      //     device: '0x61872ae41ba04f21',
+      //     'size/off': '0t0',
+      //     node: 'TCP',
+      //     name: '*:27017',
+      //     undefined: '(LISTEN)'
+      //   }
+      // ];
+      var res = _.chain(fds)
+        .filter(function(d) {
+          return _.get(d, 'node') === 'TCP';
+        })
+        .map(function(d) {
+          return {
+            port: parseInt(d.name.split(':')[1], 10),
+            pid: parseInt(d.pid, 10)
+          };
+        })
+        .value();
 
-module.exports = function(opts, fn) {
-  if (typeof opts === 'function') {
-    fn = opts;
-    opts = {};
-  }
-
-  if (process.platform === 'win32') {
-    return process.nextTick(function() {
-      fn(new Error('Sorry windows not supported yet :('));
+      debug('parsed result is', res);
+      return fn(null, res);
     });
   }
+}
 
-  debug('looking for mongodb `%j`...', opts);
-  if (opts.pid) {
-    debug('is it on pid `%s`?', opts.pid);
-    fromPID(opts.pid, fn);
-    return;
-  }
-  if (opts.port) {
-    debug('is it on port `%s`?', opts.port);
-    lsof.rawTcpPort(opts.port, function(fds) {
+function fromPort(port, fn) {
+  if (isWin) {
+    var res = [];
+
+    netstat({
+      filter: {
+        local: {
+          port: port
+        },
+        protocol: 'tcp'
+      },
+      done: function() {
+        // Called once netstat command is completely done
+        // Return list of results
+        fn(null, res);
+      }
+    }, function(data) {
+      // Called for each line that matches filter
+      // Push results to list
+      debug('netstat entry says ', data);
+      res.push({
+        port: data.local.port,
+        pid: data.pid
+      });
+    });
+  } else {
+    lsof.rawTcpPort(port, function(fds) {
       debug('lsof.rawTcpPort says `%j`', fds);
       // fds = [{
       //   state: 'listen',
@@ -92,16 +125,33 @@ module.exports = function(opts, fn) {
       debug('parsed result is', res);
       return fn(null, res);
     });
+  }
+}
+
+module.exports = function(opts, fn) {
+  if (typeof opts === 'function') {
+    fn = opts;
+    opts = {};
+  }
+
+  debug('looking for mongodb `%j`...', opts);
+  if (opts.pid) {
+    debug('is it on pid `%s`?', opts.pid);
+    fromPID(opts.pid, fn);
+  } else if (opts.port) {
+    debug('is it on port `%s`?', opts.port);
+    fromPort(opts.port, fn);
   } else {
     debug('seeing if mongod is running...');
     ps.lookup({
-      command: 'mongod',
+      command: isWin ? 'mongod.exe' : 'mongod',
       psargs: '-l'
     }, function(err, res) {
       debug('ps.lookup for mongod says `%j`', {
         err: err,
         res: res
       });
+
       if (err) {
         return fn(err);
       }
@@ -109,6 +159,7 @@ module.exports = function(opts, fn) {
       if (res.length === 0) {
         return fn(null, []);
       }
+
       // res = [{
       //   pid: '19989',
       //   command: '/Users/lucas/.mongodb/versions/mongodb/current/bin/mongod',
@@ -118,7 +169,6 @@ module.exports = function(opts, fn) {
       //     '--storageEngine=wiredTiger'
       //   ]
       // }];
-
       fromPID(parseInt(res[0].pid, 10), fn);
     });
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "figures": "^1.4.0",
     "lodash": "^3.10.1",
     "lsof": "^0.1.0",
+    "node-netstat": "^1.4.2",
     "minimist": "^1.2.0",
     "ps-node": "0.0.5"
   },


### PR DESCRIPTION
Same general premise is used to determine whether MongoDB is running on Windows.

node-netstat package is used to determine whether mongod is running on a given port or PID. node-ps is used to determine if mongod.exe is in the list of processes. It contains support for Windows already.

**Note:** node-ps currently has issue that if mongodb.exe is executed under another user, then the process cannot be retrieved without administrative rights and that is not given in node-ps. There is a fix for this and I will be submitting a PR soon enough to resolve this. I think in majority of cases, mongod.exe should be run under same user hopefully.

Use Windows equivalent function to check whether mongodb is running. Netstat is used to get MongoDB for a given PID or process. If neither is given, all running processes are analyzed using ps.locate.