### PR TITLE
Add support for Promises in module

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ require('is-mongodb-running')(function(err, res){
 });
 ```
 
+or, with promises:
+
+```javascript
+require('is-mongodb-running/promise').then(function(res) {
+  console.log(res);
+  // >>> [{pid: <12345>, port: 27017}]
+}).catch(function(err){
+  return console.error(err);
+});
+```
+
 ## License
 
 Apache 2

--- a/bin/is-mongodb-running.js
+++ b/bin/is-mongodb-running.js
@@ -14,7 +14,7 @@ var args = require('minimist')(process.argv.slice(2), {
 if (args.debug) {
   process.env.DEBUG = 'is-mongodb-running';
 }
-var lookup = require('../');
+var lookup = require('../promise');
 var pkg = require('../package.json');
 
 if (args.help || args.h) {

--- a/bin/is-mongodb-running.js
+++ b/bin/is-mongodb-running.js
@@ -26,16 +26,7 @@ if (args.version) {
   process.exit(1);
 }
 
-lookup(args, function(err, res) {
-  if (err) {
-    if (args.json) {
-      err = JSON.stringify(err, null, 2);
-    }
-    console.error(chalk.red(figures.cross), err.message); // eslint-disable-line no-console
-    console.error(chalk.gray(err.stack)); // eslint-disable-line no-console
-    process.exit(1);
-    return;
-  }
+lookup.then(function(res) {
   if (args.json) {
     console.log(JSON.stringify(res, null, 2)); // eslint-disable-line no-console
   } else {
@@ -53,4 +44,11 @@ lookup(args, function(err, res) {
         chalk.bold(d.pid));
     });
   }
+}).catch(function(err) {
+  if (args.json) {
+    err = JSON.stringify(err, null, 2);
+  }
+  console.error(chalk.red(figures.cross), err.message); // eslint-disable-line no-console
+  console.error(chalk.gray(err.stack)); // eslint-disable-line no-console
+  process.exit(1);
 });

--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,4 @@
+var util = require('util');
+var isMongodbRunning = require('./');
+
+module.exports = util.promisify(isMongodbRunning);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,15 @@
 var isMongodbRunning = require('../');
+var isMongodbRunningPromises = require('../promise');
 var assert = require('assert');
 
 describe('is-mongodb-running', function() {
   it('should work', function() {
     assert(isMongodbRunning);
+  });
+});
+
+describe('is-mongodb-running-with-promises', function() {
+  it('should work', function() {
+    assert(isMongodbRunningPromises);
   });
 });


### PR DESCRIPTION
Uses `util.promisify` built into Node v8 to create a Promise from the
is-mongodb-running function.

These changes are backwards compatible with the current callback style
function. If the Promise-style function is desired, simple
require('is-mongodb-running/promise') to get the promisified function
instead.

Updated the is-mongodb-running binary to use promises. Code looks a bit
cleaner.

Travis CI errors are unrelated to the PR. Issues are fixed in #9.

Resolves issue #5.

**Note:** @imlucas What do you think about this method? It doesn't break compatibility and it allows the use of promises. Personally, I'm on the fence about this because the util.promisify function could be called upon importing the module. Thus, the question is whether it is something the library should support.